### PR TITLE
Exit silently, if no conf found

### DIFF
--- a/telegram_notify/telegram_notify.sh
+++ b/telegram_notify/telegram_notify.sh
@@ -10,7 +10,6 @@ CRED="$(dirname "$0")/telegram_notify.conf"
 if [[ -s $CRED ]]; then
   . "$CRED"
 else 
-  echo "No credentials found at $CRED"
   exit 2
 fi
 


### PR DESCRIPTION
To avoid clogging /var/mail